### PR TITLE
[FEAT] 임대인 사전 조사 API 리팩토링

### DIFF
--- a/src/main/java/org/scoula/domain/precontract/dto/owner/OwnerContractStep1DTO.java
+++ b/src/main/java/org/scoula/domain/precontract/dto/owner/OwnerContractStep1DTO.java
@@ -39,4 +39,16 @@ public class OwnerContractStep1DTO {
       @ApiModelProperty(value = "비품 수리 책임 주체", required = true, example = "OWNER")
       @NotNull
       private ResponsibilityParty responseRepairingFixtures;
+
+      @ApiModelProperty(value = "국세/지방세 미납 여부", required = true)
+      @NotNull
+      private Boolean hasTaxArrears;
+
+      @ApiModelProperty(value = "국세/지방세 미납 금액", required = true, example = "0")
+      @NotNull
+      private int taxArrearsAmount;
+
+      @ApiModelProperty(value = "선순위 확정 일자 현황 여부", required = true)
+      @NotNull
+      private Boolean hasPriorFixedDate;
 }

--- a/src/main/java/org/scoula/domain/precontract/dto/owner/OwnerPreContractMongoDTO.java
+++ b/src/main/java/org/scoula/domain/precontract/dto/owner/OwnerPreContractMongoDTO.java
@@ -47,6 +47,7 @@ public class OwnerPreContractMongoDTO {
       private String ownerAccountNumber;
       private Integer paymentDueDate;
       private Double lateFeeInterestRate;
+      private String checkedAt;
 
       // nested 필드
       private OwnerContractStep1DTO contractStep1;

--- a/src/main/java/org/scoula/domain/precontract/vo/OwnerPreContractCheckVO.java
+++ b/src/main/java/org/scoula/domain/precontract/vo/OwnerPreContractCheckVO.java
@@ -26,6 +26,10 @@ class OwnerPreContractCheckVO {
       private ContractDuration contractDuration;
       private YesNoEnum renewalIntent;
       private ResponsibilityParty responseRepairingFixtures;
+      private Boolean hasTaxArrears;
+      private int taxArrearsAmount;
+      private Boolean hasPriorFixedDate;
+
       private List<RestoreCategoryVO> restoreCategories;
       private Boolean hasConditionLog;
       private Boolean hasPenalty;

--- a/src/main/resources/org/scoula/domain/precontract/mapper/OwnerPreContractMapper.xml
+++ b/src/main/resources/org/scoula/domain/precontract/mapper/OwnerPreContractMapper.xml
@@ -22,6 +22,9 @@
       <result property="contractDuration" column="contract_duration"/>
       <result property="renewalIntent" column="renewal_intent"/>
       <result property="responseRepairingFixtures" column="response_repairing_fixtures"/>
+      <result property="hasTaxArrears" column="has_tax_arrears" />
+      <result property="taxArrearsAmount" column="tax_arrears_amount" />
+      <result property="hasPriorFixedDate" column="has_prior_fixed_date" />
     </association>
 
     <!-- 계약 조건 Step 2 -->
@@ -122,6 +125,9 @@
       oc.contract_duration,
       oc.renewal_intent,
       oc.response_repairing_fixtures,
+      oc.has_tax_arrears,
+      oc.tax_arrears_amount,
+      oc.has_prior_fixed_date,
       oc.checked_at
     FROM owner_precontract_check oc
            JOIN identity_verification iv ON oc.identity_id = iv.identity_id
@@ -137,6 +143,9 @@
       contract_duration = #{dto.contractDuration},
       renewal_intent = #{dto.renewalIntent},
       response_repairing_fixtures = #{dto.responseRepairingFixtures},
+      has_tax_arrears = #{dto.hasTaxArrears},
+      tax_arrears_amount = #{dto.taxArrearsAmount},
+      has_prior_fixed_date = #{dto.hasPriorFixedDate},
       checked_at = now()
     WHERE contract_chat_id = #{contractChatId}
       AND EXISTS (
@@ -310,6 +319,9 @@
       opc.contract_duration,
       opc.renewal_intent,
       opc.response_repairing_fixtures,
+      opc.has_tax_arrears,
+      opc.tax_arrears_amount,
+      opc.has_prior_fixed_date,
 
       -- 계약 조건 Step 2
       opc.has_condition_log,
@@ -351,6 +363,9 @@
       opc.contract_duration AS contractDuration,
       opc.renewal_intent AS renewalIntent,
       opc.response_repairing_fixtures AS responseRepairingFixtures,
+      opc.has_tax_arrears AS hasTaxArrears,
+      opc.tax_arrears_amount AS taxArrearsAmount,
+      opc.has_prior_fixed_date AS hasPriorFixedDate,
 
       -- 계약 조건 Step 2
       opc.has_condition_log AS hasConditionLog,

--- a/src/main/resources/org/scoula/domain/precontract/mapper/OwnerPreContractMapper.xml
+++ b/src/main/resources/org/scoula/domain/precontract/mapper/OwnerPreContractMapper.xml
@@ -346,13 +346,13 @@
       iv.user_id AS userId,
       opc.rent_type AS rentType,
 
-      -- 계약 step1
-      opc.is_mortgaged AS isMortgaged,
+      -- 계약 조건 Step 1
+      opc.is_mortgaged AS mortgaged,
       opc.contract_duration AS contractDuration,
       opc.renewal_intent AS renewalIntent,
       opc.response_repairing_fixtures AS responseRepairingFixtures,
 
-      -- 계약 step2
+      -- 계약 조건 Step 2
       opc.has_condition_log AS hasConditionLog,
       opc.has_penalty AS hasPenalty,
       opc.has_priority_for_extension AS hasPriorityForExtension,
@@ -360,7 +360,13 @@
       opc.require_rent_guarantee_insurance AS requireRentGuaranteeInsurance,
       oj.allow_jeonse_right_registration AS allowJeonseRightRegistration,
 
-      -- 거주 step1 (월세)
+      -- 거주 조건 Step 1 (공통)
+      opc.insurance_burden AS insuranceBurden,
+      opc.has_notice AS hasNotice,
+      opc.owner_bank_name AS ownerBankName,
+      opc.owner_account_number AS ownerAccountNumber,
+
+      -- 거주 조건 Step 1 (월세)
       ow.payment_due_day AS paymentDueDate,
       ow.late_fee_interest_rate AS lateFeeInterestRate
 


### PR DESCRIPTION
## 🚀 관련 이슈

- close #50 

## 🔑 주요 변경사항

- 최종 데이터를 MongoDB 저장하는 mapper에 누락된 컬럼 추가
- 복구 범위 카테고리 추출 로직 summary, save-mongo에 추가

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📢 To Reviewers

## 📸 스크린샷 or 실행영상

## ↗️ 개선 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 계약 데이터에 확인 일시(checkedAt) 정보가 추가되었습니다.
  * 계약 조건 1단계에 세금 체납 여부, 체납 금액, 고정일 이전 여부 정보가 포함되었습니다.

* **개선 사항**
  * 계약 단계별로 복구 범주(restore categories) 정보가 일관되게 조회 및 반영됩니다.
  * 계약 조건 및 거주 조건 관련 추가 정보(보험 부담, 통지 여부, 은행명, 계좌번호 등)가 조회 결과에 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->