### PR TITLE
✨ feat: 채팅방 매물 가격 정보 단위 표시 수정

### DIFF
--- a/src/main/resources/org/scoula/domain/chat/mapper/ChatRoomMapper.xml
+++ b/src/main/resources/org/scoula/domain/chat/mapper/ChatRoomMapper.xml
@@ -98,18 +98,35 @@
                           WHEN 'WOLSE' THEN '월세'
                           ELSE h.lease_type END,
                       ' - ',
-                      FORMAT(h.deposit_price, 0), '만원',
-                      CASE WHEN h.monthly_rent > 0
-                               THEN CONCAT(' / ', FORMAT(h.monthly_rent, 0), '만원')
+                      CASE
+                          WHEN h.deposit_price >= 10000 THEN
+                              CONCAT(FORMAT(h.deposit_price DIV 10000, 0), '억',
+                                     CASE WHEN h.deposit_price % 10000 > 0
+                                      THEN CONCAT(' ', FORMAT(h.deposit_price % 10000, 0), '만원')
+                                          ELSE '원' END)
+                          ELSE
+                              CONCAT(FORMAT(h.deposit_price, 0), '만원')
+                          END,
+                      CASE WHEN h.monthly_rent > 0 THEN
+                               CONCAT(' / ',
+                                      CASE
+                                          WHEN h.monthly_rent >= 10000 THEN
+                                              CONCAT(FORMAT(h.monthly_rent DIV 10000, 0), '억',
+                                                     CASE WHEN h.monthly_rent % 10000 > 0
+                                                 THEN CONCAT(' ', FORMAT(h.monthly_rent % 10000, 0), '만원')
+                                                          ELSE '원' END)
+                                          ELSE
+                                              CONCAT(FORMAT(h.monthly_rent, 0), '만원')
+                                          END)
                            ELSE '' END) AS property_title,
                (SELECT hi.image_url
                 FROM home_image hi
                 WHERE hi.home_id = c.home_id
-                LIMIT 1) AS property_image_url,
-               h.deposit_price AS property_price,
-               h.lease_type AS property_type
+                   LIMIT 1) AS property_image_url,
+           h.deposit_price AS property_price,
+           h.lease_type AS property_type
         FROM chatroom c
-                 JOIN home h ON c.home_id = h.home_id
+            JOIN home h ON c.home_id = h.home_id
         WHERE c.chatroom_id = #{chatRoomId}
           AND (c.owner_id = #{userId} OR c.buyer_id = #{userId})
     </select>

--- a/src/main/resources/org/scoula/domain/chat/mapper/ChatRoomMapper.xml
+++ b/src/main/resources/org/scoula/domain/chat/mapper/ChatRoomMapper.xml
@@ -99,24 +99,24 @@
                           ELSE h.lease_type END,
                       ' - ',
                       CASE
-                          WHEN h.deposit_price >= 10000 THEN
-                              CONCAT(FORMAT(h.deposit_price DIV 10000, 0), '억',
-                                     CASE WHEN h.deposit_price % 10000 > 0
-                                      THEN CONCAT(' ', FORMAT(h.deposit_price % 10000, 0), '만원')
+                          WHEN h.deposit_price >= 100000000 THEN
+                              CONCAT(FORMAT(h.deposit_price DIV 100000000, 0), '억',
+                                     CASE WHEN (h.deposit_price % 100000000) >= 10000
+                                              THEN CONCAT(' ', FORMAT((h.deposit_price % 100000000) DIV 10000, 0), '만원')
                                           ELSE '원' END)
                           ELSE
-                              CONCAT(FORMAT(h.deposit_price, 0), '만원')
+                              CONCAT(FORMAT(h.deposit_price DIV 10000, 0), '만원')
                           END,
                       CASE WHEN h.monthly_rent > 0 THEN
                                CONCAT(' / ',
                                       CASE
-                                          WHEN h.monthly_rent >= 10000 THEN
-                                              CONCAT(FORMAT(h.monthly_rent DIV 10000, 0), '억',
-                                                     CASE WHEN h.monthly_rent % 10000 > 0
-                                                 THEN CONCAT(' ', FORMAT(h.monthly_rent % 10000, 0), '만원')
+                                          WHEN h.monthly_rent >= 100000000 THEN
+                                              CONCAT(FORMAT(h.monthly_rent DIV 100000000, 0), '억',
+                                                     CASE WHEN (h.monthly_rent % 100000000) >= 10000
+                                                              THEN CONCAT(' ', FORMAT((h.monthly_rent % 100000000) DIV 10000, 0), '만원')
                                                           ELSE '원' END)
                                           ELSE
-                                              CONCAT(FORMAT(h.monthly_rent, 0), '만원')
+                                              CONCAT(FORMAT(h.monthly_rent DIV 10000, 0), '만원')
                                           END)
                            ELSE '' END) AS property_title,
                (SELECT hi.image_url


### PR DESCRIPTION
## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
#2 
- close #1

## 🔑 주요 변경사항

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 채팅방 매물 상단 매물 가격정보 표기 수정


## ✔️ 체크 리스트

- [ ] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [ ] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [ ] 라벨을 등록했는가?
- [ ] 리뷰어를 지정했는가?

## 📢 To Reviewers

<!-- 선택 사항 -->

## 📸 스크린샷 or 실행영상

## ↗️ 개선 사항

<!-- 선택 사항 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 보증금과 월세 금액 표기가 더욱 읽기 쉽도록 "억" 단위와 "만원"/"원" 단위로 세분화되어 표시됩니다.  
  * 월세가 0일 경우 빈 문자열로 처리되어 불필요한 정보가 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->